### PR TITLE
Separate notebook requirements

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        pip install pytest pytest-cov coverage matplotlib seaborn statsmodels dowhy econml
+        pip install pytest pytest-cov coverage
     
     - name: Test with pytest
       run: |

--- a/README.md
+++ b/README.md
@@ -60,9 +60,14 @@ These tools enable researchers to test causal inference methods in controlled en
    source .venv/bin/activate  # On Windows: .venv\Scripts\activate
    ```
 
-3. Install dependencies:
+3. Install the core dependencies:
    ```bash
    pip install -r requirements.txt
+   ```
+
+4. *(Optional)* Install additional packages for notebook analysis:
+   ```bash
+   pip install -r requirements-notebook.txt
    ```
 
 ---

--- a/requirements-notebook.txt
+++ b/requirements-notebook.txt
@@ -1,0 +1,5 @@
+jupyter>=1.0.0
+seaborn>=0.11.0
+plotly>=5.5.0
+dowhy>=0.8
+econml>=0.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,5 @@
 numpy>=1.21.0
 pandas>=1.3.0
-scikit-learn>=1.0.0
-pytest>=6.0.0
 matplotlib>=3.4.0
-seaborn>=0.11.0
-plotly>=5.5.0
-dowhy>=0.8
-econml>=0.14.0
-jupyter>=1.0.0
+statsmodels>=0.13.0
+pytest>=6.0.0

--- a/src/claude_run.py
+++ b/src/claude_run.py
@@ -3,7 +3,6 @@ import pandas as pd
 import matplotlib.pyplot as plt
 import statsmodels.formula.api as smf
 from typing import Tuple, List, Dict, Optional
-import seaborn as sns
 
 def generate_population(pop_size=40_000, 
                        baseline_prevalence=0.089,


### PR DESCRIPTION
## Summary
- slim down `requirements.txt` to only core packages
- add `requirements-notebook.txt` for optional extras
- update installation docs for new optional requirements
- remove unused seaborn import
- install only needed deps in CI

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement numpy>=1.21.0)*