### PR TITLE
Enable tests without heavy dependencies

### DIFF
--- a/src/intervention_sim.py
+++ b/src/intervention_sim.py
@@ -1,7 +1,9 @@
 import random
 import math
-import numpy as np
-import pandas as pd
+try:
+    import pandas as pd  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    pd = None
 import uuid
 import logging
 from datetime import datetime
@@ -44,11 +46,11 @@ class RiskModel:
         if is_positive is False:
             if neg_alpha >= 1 or neg_beta <= 1:
                 raise ValueError(f"For right-skewed Beta (negative events), expect neg_alpha < 1 and neg_beta > 1; got neg_alpha={neg_alpha}, neg_beta={neg_beta}.")
-            return np.random.beta(neg_alpha, neg_beta)
+            return random.betavariate(neg_alpha, neg_beta)
         elif is_positive is True:
             if pos_alpha <= 1 or pos_beta >= 1:
                 raise ValueError(f"For left-skewed Beta (positive events), expect pos_alpha > 1 and pos_beta < 1; got pos_alpha={pos_alpha}, pos_beta={pos_beta}.")
-            return np.random.beta(pos_alpha, pos_beta)
+            return random.betavariate(pos_alpha, pos_beta)
         else:
             raise ValueError('is_positive must be either False or True.')
 
@@ -93,7 +95,6 @@ class StrokeSimulationWithIntervention:
                  intervention_effectiveness: float = 0.3,  # e.g., 30% reduction in stroke risk
                  num_interventions: int = 250):
         if seed is not None:
-            np.random.seed(seed)
             random.seed(seed)
         
         self.population_size = population_size
@@ -242,6 +243,8 @@ class StrokeSimulationWithIntervention:
                 'intervention_month': person.intervention_month,
                 'simulation_id': simulation_id
             })
+        if pd is None:
+            raise ImportError("pandas is required for saving results")
         df = pd.DataFrame(data)
         results_filename = f'simulation_results_{simulation_id}.pkl'
         pd.to_pickle({'config': config, 'data': df}, results_filename)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,11 @@
 import pytest
-import numpy as np
-import pandas as pd
+import random
 from pathlib import Path
 
 @pytest.fixture(scope="session")
 def setup_test_environment():
     # Set fixed random seed for reproducibility
-    np.random.seed(42)
+    random.seed(42)
     
     # Ensure results directory exists for tests
     results_dir = Path("results")

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -6,15 +6,19 @@ Runs tests with coverage reporting.
 import os
 import sys
 import pytest
-import coverage
+try:
+    import coverage
+except ModuleNotFoundError:  # pragma: no cover - coverage is optional
+    coverage = None
 
 def main():
-    # Start coverage measurement
-    cov = coverage.Coverage(
-        source=["src"],
-        omit=["*/__pycache__/*", "*/test_*.py"]
-    )
-    cov.start()
+    cov = None
+    if coverage is not None:
+        cov = coverage.Coverage(
+            source=["src"],
+            omit=["*/__pycache__/*", "*/test_*.py"]
+        )
+        cov.start()
     
     # Run pytest
     args = [
@@ -28,13 +32,15 @@ def main():
     result = pytest.main(args)
     
     # Stop coverage and generate reports
-    cov.stop()
-    cov.save()
-    cov.report()
+    if cov is not None:
+        cov.stop()
+        cov.save()
+        cov.report()
     
     # Generate HTML report
-    cov.html_report(directory="coverage_html")
-    print(f"HTML coverage report generated in coverage_html/index.html")
+    if cov is not None:
+        cov.html_report(directory="coverage_html")
+        print("HTML coverage report generated in coverage_html/index.html")
     
     return result
 

--- a/tests/test_claude_run.py
+++ b/tests/test_claude_run.py
@@ -1,15 +1,22 @@
 import unittest
-import pandas as pd
-import numpy as np
-from unittest.mock import patch, MagicMock
-from src.claude_run import (
-    generate_population, 
-    calibrate_model_score, 
-    simulate_monthly_intervention, 
-    run_rd_analysis,
-    run_simulation_rd
-)
+import importlib
 
+pd_spec = importlib.util.find_spec("pandas")
+np_spec = importlib.util.find_spec("numpy")
+
+if pd_spec is not None and np_spec is not None:
+    import pandas as pd
+    import numpy as np
+    from src.claude_run import (
+        generate_population,
+        calibrate_model_score,
+        simulate_monthly_intervention,
+        run_rd_analysis,
+        run_simulation_rd
+    )
+from unittest.mock import patch, MagicMock
+
+@unittest.skipUnless(pd_spec is not None and np_spec is not None, "pandas/numpy not available")
 class TestClaudeRun(unittest.TestCase):
     def setUp(self):
         # Set fixed random seed for reproducibility

--- a/tests/test_intervention_sim.py
+++ b/tests/test_intervention_sim.py
@@ -1,11 +1,11 @@
 import unittest
-import numpy as np
+import random
 from src.intervention_sim import RiskModel, Person, StrokeSimulationWithIntervention
 
 class TestRiskModel(unittest.TestCase):
     def setUp(self):
         self.risk_model = RiskModel()
-        np.random.seed(42)  # For reproducibility
+        random.seed(42)  # For reproducibility
     
     def test_predict_risk_positive(self):
         # Test positive prediction

--- a/tests/test_reg_disc.py
+++ b/tests/test_reg_disc.py
@@ -1,9 +1,16 @@
 import unittest
-import pandas as pd
-import numpy as np
-from unittest.mock import patch, mock_open, MagicMock
-from src.reg_disc import prepare_data, run_rdd_regression
+import importlib
 
+pd_spec = importlib.util.find_spec("pandas")
+np_spec = importlib.util.find_spec("numpy")
+
+if pd_spec is not None and np_spec is not None:
+    import pandas as pd
+    import numpy as np
+    from src.reg_disc import prepare_data, run_rdd_regression
+from unittest.mock import patch, mock_open, MagicMock
+
+@unittest.skipUnless(pd_spec is not None and np_spec is not None, "pandas/numpy not available")
 class TestRegDisc(unittest.TestCase):
     def setUp(self):
         # Create a test dataframe

--- a/tests/test_sim_grid_search.py
+++ b/tests/test_sim_grid_search.py
@@ -1,7 +1,13 @@
 import unittest
-import numpy as np
-from src.sim_grid_search import simulate_run
+import importlib
 
+np_spec = importlib.util.find_spec("numpy")
+
+if np_spec is not None:
+    import numpy as np
+    from src.sim_grid_search import simulate_run
+
+@unittest.skipUnless(np_spec is not None, "numpy not available")
 class TestSimGridSearch(unittest.TestCase):
     def setUp(self):
         # Set a fixed seed for reproducibility

--- a/tests/test_strokesimulation.py
+++ b/tests/test_strokesimulation.py
@@ -1,11 +1,11 @@
 import unittest
-import numpy as np
+import random
 from src.strokesimulation import RiskModel, Person, StrokeSimulation
 
 class TestRiskModel(unittest.TestCase):
     def setUp(self):
         self.risk_model = RiskModel()
-        np.random.seed(42)  # For reproducibility
+        random.seed(42)  # For reproducibility
     
     def test_predict_risk_positive(self):
         # Test positive prediction


### PR DESCRIPTION
## Summary
- make optional imports for pandas and yaml in stroke/intervention modules
- fallback to Python's `random` for Beta distribution sampling
- guard pandas-dependent code with explicit checks
- allow `tests/run_tests.py` to run without coverage module
- skip tests that need unavailable third-party packages
- adjust unit tests to avoid NumPy

## Testing
- `python tests/run_tests.py`