### PR TITLE
Fix mypy errors

### DIFF
--- a/src/claude_run.py
+++ b/src/claude_run.py
@@ -1,7 +1,7 @@
 import numpy as np
-import pandas as pd
+import pandas as pd  # type: ignore
 import matplotlib.pyplot as plt
-import statsmodels.formula.api as smf
+import statsmodels.formula.api as smf  # type: ignore
 
 
 def generate_population(

--- a/src/intervention_sim.py
+++ b/src/intervention_sim.py
@@ -136,11 +136,15 @@ class StrokeSimulationWithIntervention:
         self.num_interventions = num_interventions
 
         # Logs and results storage
-        self.stroke_log = []  # List of tuples: (person_id, month_of_stroke)
+        self.stroke_log: List[tuple[int, int]] = []
+        # List of tuples: (person_id, month_of_stroke)
         self.monthly_stroke_counts = [0] * self.total_months
         self.monthly_alive_counts = [0] * self.total_months
         # For each month, record the ranking of the top intervention candidates:
-        self.intervention_log = []  # List of tuples: (month, [ (person_id, risk_score, intervention_flag), ... ])
+        self.intervention_log: List[
+            tuple[int, list[tuple[int, float | None, bool]]]
+        ] = []
+        # List of tuples: (month, [ (person_id, risk_score, intervention_flag), ... ])
 
         self.population: List[Person] = []
         self._initialize_population()
@@ -165,7 +169,10 @@ class StrokeSimulationWithIntervention:
         """Simulate non-stroke deaths for alive individuals."""
         for person in self.population:
             if person.is_alive and not person.has_stroke:
-                if random.random() < self.monthly_mortality_prob:
+                if (
+                    self.monthly_mortality_prob is not None
+                    and random.random() < self.monthly_mortality_prob
+                ):
                     person.is_alive = False
 
     def run_simulation(self):

--- a/src/reg_disc.py
+++ b/src/reg_disc.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 import argparse
 import pickle
-import pandas as pd
+import pandas as pd  # type: ignore
 import numpy as np
-import statsmodels.formula.api as smf
+import statsmodels.formula.api as smf  # type: ignore
 import matplotlib.pyplot as plt
 
 

--- a/src/sim_grid_search.py
+++ b/src/sim_grid_search.py
@@ -1,6 +1,6 @@
 import numpy as np
 import matplotlib.pyplot as plt
-from scipy.stats import beta as beta_dist
+from scipy.stats import beta as beta_dist  # type: ignore
 import logging
 
 # Configure logging.

--- a/src/strokesimulation.py
+++ b/src/strokesimulation.py
@@ -184,7 +184,7 @@ class StrokeSimulation:
         """
         if self.age_distribution and month > 0 and (month % 12 == 0):
             for person in self.population:
-                if person.is_alive:
+                if person.is_alive and person.age is not None:
                     person.age += 1
 
     def _apply_mortality(self, month: int) -> None:
@@ -198,7 +198,10 @@ class StrokeSimulation:
         """
         for person in self.population:
             if person.is_alive and not person.has_stroke:
-                if random.random() < self.monthly_mortality_prob:
+                if (
+                    self.monthly_mortality_prob is not None
+                    and random.random() < self.monthly_mortality_prob
+                ):
                     person.is_alive = False
 
     def _apply_stroke(self, month: int) -> None:
@@ -283,7 +286,8 @@ class SimulationRunner(StrokeSimulation):
             self.master_df = None
         else:
             self.master_df = pd.DataFrame()  # To accumulate monthly DataFrames
-        self.monthly_metrics = []  # To store performance metrics for each month
+        self.monthly_metrics: List[dict[str, float | int]] = []
+        # To store performance metrics for each month
 
     def run_all(self) -> dict:
         self.run_simulation()


### PR DESCRIPTION
## Summary
- adjust age update and mortality logic in `StrokeSimulation`
- type annotations for logs and metrics
- ignore missing type stubs for pandas, statsmodels, and scipy
- fix mortality check in intervention simulation

## Testing
- `flake8 src tests`
- `mypy src`
- `pytest -q`