### PR TITLE
Load params from configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,13 @@ This will use the parameters defined in `config.yaml` to run the simulation.
 
 #### Intervention Simulation
 
-Run a simulation with monthly targeted interventions:
+Run a simulation with monthly targeted interventions using the parameters from `config.yaml`:
 
 ```bash
 python -c "from src.intervention_sim import main; main()"
 ```
 
-This simulation selects high-risk individuals each month for intervention and reduces their stroke probability.
+This simulation selects high-risk individuals each month for intervention and reduces their stroke probability based on the configuration values.
 
 ### Causal Analysis
 

--- a/config.yaml
+++ b/config.yaml
@@ -6,3 +6,5 @@ include_mortality: true
 annual_mortality_rate: 0.01
 age_distribution: true
 initial_age_range: [30, 70]
+intervention_effectiveness: 0.2
+num_interventions: 250

--- a/src/intervention_sim.py
+++ b/src/intervention_sim.py
@@ -7,6 +7,7 @@ except ModuleNotFoundError:  # pragma: no cover - optional dependency
 import uuid
 import logging
 from src.logging_utils import log_calls, log_all_methods
+from src.strokesimulation import load_config
 from datetime import datetime
 from pathlib import Path
 from dataclasses import dataclass, field
@@ -367,21 +368,12 @@ class SimulationRunnerWithIntervention(StrokeSimulationWithIntervention):
 
 @log_calls
 def main():
-    simulation_params = {
-        "population_size": 40000,
-        "annual_incidence_rate": 0.05,  # Input annual stroke incidence rate
-        "num_years": 2,
-        "seed": 42,
-        "include_mortality": True,
-        "annual_mortality_rate": 0.01,
-        "age_distribution": True,
-        "initial_age_range": (30, 70),
-        "risk_model": RiskModel(),
-        "intervention_effectiveness": 0.2,  # 20% reduction in stroke risk for intervened patients
-        "num_interventions": 250,
-    }
+    config = load_config("config.yaml")
+    config.setdefault("intervention_effectiveness", 0.2)
+    config.setdefault("num_interventions", 250)
+    config["risk_model"] = RiskModel()
 
-    runner = SimulationRunnerWithIntervention(simulation_params)
+    runner = SimulationRunnerWithIntervention(config)
     runner.run_all()
     runner.summarize_results()
 


### PR DESCRIPTION
## Summary
- import `load_config` into the intervention simulation
- read intervention simulation parameters from `config.yaml`
- expand `config.yaml` with intervention specific parameters
- document configuration usage in the README

## Testing
- `flake8 src tests`
- `mypy --explicit-package-bases src`
- `python tests/run_tests.py`